### PR TITLE
Add database support to solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 *.userosscache
 *.sln.docstates
 
+# Sqlite Databases
+*.db
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/samples/SqlitePlayground/Program.cs
+++ b/samples/SqlitePlayground/Program.cs
@@ -1,44 +1,97 @@
 ﻿using Microsoft.Data.Sqlite;
+using System.Text;
 
-Console.WriteLine("Checking if the local DB file is already sitting on disk next to this executable");
-
-if (File.Exists("MyLocalDatabase.db"))
+internal class Program
 {
-    Console.WriteLine("It is, deleting...");
-    File.Delete("MyLocalDatabase.db");
-}
-
-Console.WriteLine("Opening a connection to a local database instance, which will create the file if it doesn't yet exist");
-using (var connection = new SqliteConnection("Data Source=MyLocalDatabase.db"))
-{
-    connection.Open();
-
-    Console.WriteLine("Creating a table in the database");
-    var command = connection.CreateCommand();
-    command.CommandText = "CREATE TABLE TestTbl1 (ID INT IDENTITY(1,1), Name NVARCHAR(255))";
-    command.ExecuteNonQuery();
-
-    Console.WriteLine("Inserting some data");
-    command = connection.CreateCommand();
-    command.CommandText = "INSERT INTO TestTbl1 (Name) VALUES ('jeffand')";
-    command.ExecuteNonQuery();
-
-    command = connection.CreateCommand();
-    command.CommandText = "INSERT INTO TestTbl1 (Name) VALUES ('otherperson')";
-    command.ExecuteNonQuery();
-
-    command = connection.CreateCommand();
-    command.CommandText = "SELECT Name from TestTbl1";
-    command.ExecuteNonQuery();
-
-    Console.WriteLine("Reading the data");
-    using (var reader = command.ExecuteReader())
+    private static void Main(string[] args)
     {
-        while (reader.Read())
-        {
-            var name = reader.GetString(0);
+        Console.WriteLine("Checking if the local DB file is already sitting on disk next to this executable");
 
-            Console.WriteLine($"Hello, {name}!");
+        if (File.Exists("MyLocalDatabase.db"))
+        {
+            Console.WriteLine("It is, deleting...");
+            File.Delete("MyLocalDatabase.db");
+        }
+
+        Console.WriteLine("Opening a connection to a local database instance, which will create the file if it doesn't yet exist");
+        using (var connection = new SqliteConnection("Data Source=MyLocalDatabase.db"))
+        {
+            connection.Open();
+
+            Console.WriteLine("Connection open, enter a command");
+
+            string? cmd = Console.ReadLine();
+
+            while (!string.IsNullOrEmpty(cmd))
+            {
+                try
+                {
+                    using (var sqlCmd = connection.CreateCommand())
+                    {
+                        sqlCmd.CommandText = cmd;
+
+                        using (var dataReader = sqlCmd.ExecuteReader())
+                        {
+                            while (dataReader.Read())
+                            {
+                                StringBuilder outputLine = new StringBuilder();
+
+                                for (int i = 0; i < dataReader.FieldCount; i++)
+                                {
+                                    if (i > 0)
+                                    {
+                                        outputLine.Append(", ");
+                                    }
+
+                                    if (dataReader[i] != null)
+                                    {
+                                        outputLine.Append(dataReader[i]);
+                                    }
+                                }
+
+                                Console.WriteLine(outputLine);
+                            }
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                }
+
+                Console.WriteLine("Done, next command please");
+                cmd = Console.ReadLine();
+            }
+
+            // Examples of command run explicitly
+            //Console.WriteLine("Creating a table in the database");
+            //var command = connection.CreateCommand();
+            //command.CommandText = "CREATE TABLE TestTbl1 (ID INT IDENTITY(1,1), Name NVARCHAR(255))";
+            //command.ExecuteNonQuery();
+
+            //Console.WriteLine("Inserting some data");
+            //command = connection.CreateCommand();
+            //command.CommandText = "INSERT INTO TestTbl1 (Name) VALUES ('jeffand')";
+            //command.ExecuteNonQuery();
+
+            //command = connection.CreateCommand();
+            //command.CommandText = "INSERT INTO TestTbl1 (Name) VALUES ('otherperson')";
+            //command.ExecuteNonQuery();
+
+            //command = connection.CreateCommand();
+            //command.CommandText = "SELECT Name from TestTbl1";
+            //command.ExecuteNonQuery();
+
+            //Console.WriteLine("Reading the data");
+            //using (var reader = command.ExecuteReader())
+            //{
+            //    while (reader.Read())
+            //    {
+            //        var name = reader.GetString(0);
+
+            //        Console.WriteLine($"Hello, {name}!");
+            //    }
+            //}
         }
     }
 }

--- a/samples/SqlitePlayground/Program.cs
+++ b/samples/SqlitePlayground/Program.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Data.Sqlite;
+
+Console.WriteLine("Checking if the local DB file is already sitting on disk next to this executable");
+
+if (File.Exists("MyLocalDatabase.db"))
+{
+    Console.WriteLine("It is, deleting...");
+    File.Delete("MyLocalDatabase.db");
+}
+
+Console.WriteLine("Opening a connection to a local database instance, which will create the file if it doesn't yet exist");
+using (var connection = new SqliteConnection("Data Source=MyLocalDatabase.db"))
+{
+    connection.Open();
+
+    Console.WriteLine("Creating a table in the database");
+    var command = connection.CreateCommand();
+    command.CommandText = "CREATE TABLE TestTbl1 (ID INT IDENTITY(1,1), Name NVARCHAR(255))";
+    command.ExecuteNonQuery();
+
+    Console.WriteLine("Inserting some data");
+    command = connection.CreateCommand();
+    command.CommandText = "INSERT INTO TestTbl1 (Name) VALUES ('jeffand')";
+    command.ExecuteNonQuery();
+
+    command = connection.CreateCommand();
+    command.CommandText = "INSERT INTO TestTbl1 (Name) VALUES ('otherperson')";
+    command.ExecuteNonQuery();
+
+    command = connection.CreateCommand();
+    command.CommandText = "SELECT Name from TestTbl1";
+    command.ExecuteNonQuery();
+
+    Console.WriteLine("Reading the data");
+    using (var reader = command.ExecuteReader())
+    {
+        while (reader.Read())
+        {
+            var name = reader.GetString(0);
+
+            Console.WriteLine($"Hello, {name}!");
+        }
+    }
+}

--- a/samples/SqlitePlayground/SqlitePlayground.csproj
+++ b/samples/SqlitePlayground/SqlitePlayground.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/samples/SqlitePlayground/SqlitePlayground.sln
+++ b/samples/SqlitePlayground/SqlitePlayground.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33424.131
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SqlitePlayground", "SqlitePlayground.csproj", "{6FF9846B-C4B6-463D-82CC-70EEEDBE476D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6FF9846B-C4B6-463D-82CC-70EEEDBE476D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6FF9846B-C4B6-463D-82CC-70EEEDBE476D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6FF9846B-C4B6-463D-82CC-70EEEDBE476D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6FF9846B-C4B6-463D-82CC-70EEEDBE476D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {ACDDB1E2-1067-41F5-A05D-F3811792C7DD}
+	EndGlobalSection
+EndGlobal

--- a/source/WaitlistApplication/DatabaseManager.cs
+++ b/source/WaitlistApplication/DatabaseManager.cs
@@ -1,0 +1,170 @@
+﻿using Microsoft.Data.Sqlite;
+using System.Data.Common;
+using System.Data.SqlClient;
+
+namespace WaitlistApplication
+{
+    public class DatabaseManager
+    {
+        private static object lockObj = new object();
+        private static DatabaseManager? singletonInstance = null;
+
+        // Database names and variables
+        const string WAITLIST_DBNAME = "WaitlistApp";
+        const string SQLEXPRESS_MASTER_CONNECTIONSTRING = @"SERVER=.\SQLEXPRESS01;Database=master;Integrated Security=SSPI";
+        const string SQLEXPRESS_WAITLIST_CONNECTIONSTRING = $@"SERVER=.\SQLEXPRESS01;Database={WAITLIST_DBNAME};Integrated Security=SSPI";
+        const string SQLITE_DBNAME = $"{WAITLIST_DBNAME}.db";
+        const string SQLITE_CONNECTIONSTRING = $"Data Source={SQLITE_DBNAME}";
+
+        private DatabaseManager()
+        {
+            this.InitializeDatabase();
+        }
+
+        private DatabaseType PickDatabaseType()
+        {
+            // By default, connect to a Sqlite in-memory DB instance, but allow 
+            // fallbacks to SqlExpress or Azure SQL as necessary
+            return DatabaseType.Sqlite;
+        }
+
+        private void InitializeDatabase()
+        {
+            switch (this.PickDatabaseType())
+            {
+                case DatabaseType.Sqlite:
+                    InitializeSqlite();
+                    break;
+                case DatabaseType.SqlExpress:
+                    InitializeSqlExpress();
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        private void InitializeSqlExpress()
+        {
+            // See if the SQLExpress database exists, and if not, create it
+            using (DbConnection dbConn = this.CreateConnection())
+            {
+                dbConn.Open();
+                var sqlCmd = dbConn.CreateCommand();
+                sqlCmd.CommandText = $"IF DB_ID('{WAITLIST_DBNAME}') IS NULL CREATE DATABASE {WAITLIST_DBNAME}";
+                sqlCmd.ExecuteNonQuery();
+            }
+
+            // Now connect to the waitlist database and initialize schema
+            using (SqlConnection sqlConn = new SqlConnection(SQLEXPRESS_WAITLIST_CONNECTIONSTRING))
+            {
+                sqlConn.Open();
+
+                InitializeSchema(sqlConn);
+            }
+        }
+
+        private void InitializeSqlite()
+        {
+            // Clean up any existing file
+            if (File.Exists(SQLITE_DBNAME))
+            {
+                File.Delete(SQLITE_DBNAME);
+            }
+
+            using (var connection = new SqliteConnection($"Data Source={SQLITE_DBNAME}"))
+            {
+                connection.Open();
+
+                InitializeSchema(connection);
+            }
+        }
+
+        private bool DoesTableExist(DbConnection dbConn, string tableName)
+        {
+            // Sqlite and SqlExpress/Azure have different syntax for checking if tables exist
+            using (var command = dbConn.CreateCommand())
+            {
+                switch (this.PickDatabaseType())
+                {
+                    case DatabaseType.Sqlite:
+                        command.CommandText = $"SELECT 1 FROM sqlite_master WHERE type='table' AND name='{tableName}'";
+                        break;
+                    case DatabaseType.SqlExpress:
+                        command.CommandText = $"SELECT 1 FROM sys.tables WHERE name='{tableName}'";
+                        break;
+                    default:
+                        throw new NotImplementedException();
+                }
+
+                return command.ExecuteScalar() != null;
+            }
+        }
+
+        private void InitializeSchema(DbConnection dbConn)
+        {
+            // See if Restaurant table exists, and if not, initialize the schema
+            if (!DoesTableExist(dbConn, "Restaurant"))
+            {
+                using (var command = dbConn.CreateCommand())
+                {
+                    command.CommandText = @"
+                        CREATE TABLE Restaurant (
+                            ID UNIQUEIDENTIFIER NOT NULL,
+                            Name NVARCHAR(255) NOT NULL
+                        )";
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Singleton instance of the Database Manager class.
+        /// </summary>
+        public static DatabaseManager Instance
+        {
+            get
+            {
+                if (singletonInstance == null)
+                {
+                    // Use the double-check-lock pattern since initialization of the DBManager is
+                    // extremely expensive, and likely to cause race conditions if not synchronized
+                    lock (lockObj)
+                    {
+                        if (singletonInstance == null)
+                        {
+                            singletonInstance = new DatabaseManager();
+                        }
+                    }
+                }
+
+                return singletonInstance;
+            }
+        }
+
+        /// <summary>
+        /// Ensures that the database connection is successful and that the database is ready for the program to run.
+        /// </summary>
+        public static void Initialize()
+        {
+            // The singleton instance automatically initializes during construction, so just calling the singleton will ensure initialization
+            var dbInstance = Instance;
+        }
+
+        /// <summary>
+        /// Creates a connection to the currently attached database.
+        /// </summary>
+        /// <returns>A database connection which is not yet opened.</returns>
+        public DbConnection CreateConnection()
+        {
+            switch (this.PickDatabaseType())
+            {
+                case DatabaseType.Sqlite:
+                    return new SqliteConnection(SQLITE_CONNECTIONSTRING);
+                case DatabaseType.SqlExpress:
+                    return new SqlConnection(SQLEXPRESS_MASTER_CONNECTIONSTRING);
+            }
+
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/source/WaitlistApplication/DatabaseType.cs
+++ b/source/WaitlistApplication/DatabaseType.cs
@@ -1,0 +1,9 @@
+﻿namespace WaitlistApplication
+{
+    public enum DatabaseType
+    {
+        Sqlite,
+        SqlExpress,
+        AzureSql,
+    }
+}

--- a/source/WaitlistApplication/Program.cs
+++ b/source/WaitlistApplication/Program.cs
@@ -1,3 +1,8 @@
+using WaitlistApplication;
+
+// Initialize the database connection before starting anything else to avoid race conditions
+DatabaseManager.Initialize();
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.

--- a/source/WaitlistApplication/WaitlistApplication.csproj
+++ b/source/WaitlistApplication/WaitlistApplication.csproj
@@ -6,4 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+  </ItemGroup>
+
 </Project>

--- a/test/WaitlistUnitTests/DatabaseManagerTests.cs
+++ b/test/WaitlistUnitTests/DatabaseManagerTests.cs
@@ -1,0 +1,35 @@
+using WaitlistApplication;
+
+namespace WaitlistUnitTests
+{
+    public class DatabaseManagerTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+            // Initialize an instance of the database manager, which should pre-populate the schema
+            DatabaseManager dbManager = DatabaseManager.Instance;
+        }
+
+        [Test]
+        public void VerifyRestaurantTableExists()
+        {
+            // Arrange
+            DatabaseManager dbManager = DatabaseManager.Instance;
+            using (var dbConn = dbManager.CreateConnection())
+            {
+                dbConn.Open();
+
+                using (var sqlCmd = dbConn.CreateCommand())
+                {
+                    // Act
+                    sqlCmd.CommandText = "SELECT COUNT(*) FROM Restaurant";
+                    var result = sqlCmd.ExecuteScalar();
+
+                    // Assert
+                    Assert.That(result, Is.Not.Null);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds dependencies on both Sqlite (an in-memory database) as well as the SqlExpress client libraries. This allows both running locally against a SqlExpress instance while writing code so SSMS can be used to manually edit SQL data, as well as running in-proc in github actions on linux. The pattern should also allow future additions of Azure Sql for online instance support.

Also included a SqlitePlayground sample app to allow running queries against Sqlite to test syntax differences when necessary.